### PR TITLE
Remove Elasticsearch PVCs of old nodes

### DIFF
--- a/pkg/controller/elasticsearch/driver/nodes.go
+++ b/pkg/controller/elasticsearch/driver/nodes.go
@@ -46,6 +46,10 @@ func (d *defaultDriver) reconcileNodeSpecs(
 		return results.WithError(err)
 	}
 
+	if err := GarbageCollectPVCs(d.K8sClient(), d.Scheme(), d.ES, actualStatefulSets, expectedResources.StatefulSets()); err != nil {
+		return results.WithError(err)
+	}
+
 	esState := NewMemoizingESState(esClient)
 
 	// Phase 1: apply expected StatefulSets resources and scale up.

--- a/pkg/controller/elasticsearch/driver/pvc.go
+++ b/pkg/controller/elasticsearch/driver/pvc.go
@@ -1,0 +1,122 @@
+package driver
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
+)
+
+// GarbageCollectPVCs ensures PersistentVolumeClaims created for the given es resource are deleted
+// when no longer used, since this is not done automatically by the StatefulSet controller.
+// Related issue in the k8s repo: https://github.com/kubernetes/kubernetes/issues/55045
+// It sets an owner reference to automatically delete PVCs on es deletion, and garbage collects
+// unused PVCs of existing StatefulSets.
+// Note we do **not** delete the corresponding PersistentVolumes but just the PersistentVolumeClaims.
+// PV deletion is left to the responsibility of the storage class reclaim policy.
+func GarbageCollectPVCs(
+	k8sClient k8s.Client,
+	scheme *runtime.Scheme,
+	es v1alpha1.Elasticsearch,
+	actualStatefulSets sset.StatefulSetList,
+	expectedStatefulSets sset.StatefulSetList,
+) error {
+	// PVCs are using the same labels as their corresponding StatefulSet, so we can filter on ES cluster name.
+	var pvcs corev1.PersistentVolumeClaimList
+	if err := k8sClient.List(&client.ListOptions{
+		Namespace:     es.Namespace,
+		LabelSelector: label.NewLabelSelectorForElasticsearch(es),
+	}, &pvcs); err != nil {
+		return err
+	}
+	if err := reconcilePVCsOwnerRef(k8sClient, scheme, es, pvcs.Items); err != nil {
+		return err
+	}
+	return deleteUnusedPVCs(k8sClient, pvcs.Items, actualStatefulSets, expectedStatefulSets)
+}
+
+// reconcilePVCsOwnerRef ensures PVCs created for this Elasticsearch cluster have an owner ref set to
+// the Elasticsearch resource, so they are deleted automatically upon Elasticsearch deletion.
+// A subtle race condition exists: users may still end up with leftover PVCs if the Elasticsearch resource
+// gets deleted right after creation or update, before this is called.
+func reconcilePVCsOwnerRef(
+	k8sClient k8s.Client,
+	scheme *runtime.Scheme,
+	es v1alpha1.Elasticsearch,
+	pvcs []corev1.PersistentVolumeClaim,
+) error {
+	for _, pvc := range pvcs {
+		if err := setPVCOwnerRef(k8sClient, scheme, es, pvc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// setPVCOwnerRef sets an owner reference targeting es on the given pvc, if not already set.
+func setPVCOwnerRef(
+	k8sClient k8s.Client,
+	scheme *runtime.Scheme,
+	es v1alpha1.Elasticsearch,
+	pvc corev1.PersistentVolumeClaim,
+) error {
+	for _, ref := range pvc.OwnerReferences {
+		if ref.Name == es.Name {
+			// already set, nothing to do
+			return nil
+		}
+	}
+	log.V(1).Info("Setting PersistentVolumeClaim owner reference",
+		"namespace", es.Namespace,
+		"es_name", es.Name,
+		"pvc_name", pvc.Name,
+	)
+	if err := controllerutil.SetControllerReference(&es, &pvc, scheme); err != nil {
+		return err
+	}
+	return k8sClient.Update(&pvc)
+}
+
+// deleteUnusedPVCs deletes PVC resources that are not required anymore for this cluster.
+func deleteUnusedPVCs(
+	k8sClient k8s.Client,
+	pvcs []corev1.PersistentVolumeClaim,
+	actualStatefulSets sset.StatefulSetList,
+	expectedStatefulSets sset.StatefulSetList,
+) error {
+	for _, pvc := range pvcsToRemove(pvcs, actualStatefulSets, expectedStatefulSets) {
+		log.Info("Deleting PVC", "namespace", pvc.Namespace, "pvc_name", pvc.Name)
+		if err := k8sClient.Delete(&pvc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// pvcsToRemove filters the given pvcs to ones that can be safely removed based on Pods
+// of actual and expected StatefulSets.
+func pvcsToRemove(
+	pvcs []corev1.PersistentVolumeClaim,
+	actualStatefulSets sset.StatefulSetList,
+	expectedStatefulSets sset.StatefulSetList,
+) []corev1.PersistentVolumeClaim {
+	// Build the list of PVCs from both actual & expected StatefulSets (may contain duplicate entries).
+	// The list may contain PVCs for Pods that do not exist (eg. not created yet), but does not
+	// consider Pods in the process of being deleted (but not deleted yet), since already covered
+	// by checking expectations earlier in the process.
+	// Then, just return existing PVCs that are not part of that list.
+	expectedPVCs := append(actualStatefulSets.PVCNames(), expectedStatefulSets.PVCNames()...)
+	var toRemove []corev1.PersistentVolumeClaim
+	for _, pvc := range pvcs {
+		if !stringsutil.StringInSlice(pvc.Name, expectedPVCs) {
+			toRemove = append(toRemove, pvc)
+		}
+	}
+	return toRemove
+}

--- a/pkg/controller/elasticsearch/driver/pvc_test.go
+++ b/pkg/controller/elasticsearch/driver/pvc_test.go
@@ -1,0 +1,217 @@
+package driver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/label"
+	"github.com/elastic/cloud-on-k8s/pkg/controller/elasticsearch/sset"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/k8s"
+)
+
+func Test_reconcilePVCsOwnerRef(t *testing.T) {
+	require.NoError(t, v1alpha1.AddToScheme(scheme.Scheme))
+	es := v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"}}
+	tests := []struct {
+		name      string
+		k8sClient k8s.Client
+		pvcs      []corev1.PersistentVolumeClaim
+	}{
+		{
+			name:      "no pvcs",
+			k8sClient: k8s.WrapClient(fake.NewFakeClient()),
+			pvcs:      nil,
+		},
+		{
+			name: "3 PVCs with ownerRef not set",
+			k8sClient: k8s.WrapClient(fake.NewFakeClient(
+				buildPVCPtr("pvc1"), buildPVCPtr("pvc2"), buildPVCPtr("pvc3"))),
+			pvcs: []corev1.PersistentVolumeClaim{
+				buildPVC("pvc1"), buildPVC("pvc2"), buildPVC("pvc3")},
+		},
+		{
+			name: "2nd PVC has ownerRef already set",
+			k8sClient: k8s.WrapClient(fake.NewFakeClient(
+				buildPVCPtr("pvc1"), buildPVCPtr("pvc2", es.Name), buildPVCPtr("pvc3"))),
+			pvcs: []corev1.PersistentVolumeClaim{
+				buildPVC("pvc1"), buildPVC("pvc2", es.Name), buildPVC("pvc3")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, reconcilePVCsOwnerRef(tt.k8sClient, scheme.Scheme, es, tt.pvcs))
+			// check all pvcs have an owner reference
+			var pvcs corev1.PersistentVolumeClaimList
+			require.NoError(t, tt.k8sClient.List(&client.ListOptions{}, &pvcs))
+			require.Equal(t, len(tt.pvcs), len(pvcs.Items))
+			for _, pvc := range pvcs.Items {
+				require.NotEmpty(t, pvc.OwnerReferences)
+				require.Equal(t, es.Name, pvc.OwnerReferences[0].Name)
+			}
+		})
+	}
+}
+
+func Test_setPVCOwnerRef(t *testing.T) {
+	// Test_reconcilePVCsOwnerRef covers most of the logic already.
+	// This test focuses on testing that no update is issued if the owner ref is already set.
+	require.NoError(t, v1alpha1.AddToScheme(scheme.Scheme))
+	es := v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"}}
+	// simulate no PVC in the apiserver: the update would fail if it happens
+	k8sClient := k8s.WrapClient(fake.NewFakeClient())
+	// pass a PVC whose owner ref is already set
+	err := setPVCOwnerRef(k8sClient, scheme.Scheme, es, corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pvc2",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: es.Name,
+				},
+			}}},
+	)
+	// the call should not attempt to update the resource: no error returned here
+	require.NoError(t, err)
+}
+
+func buildSsetWithClaims(name string, replicas int32, claims ...string) appsv1.StatefulSet {
+	s := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      name,
+			Labels: map[string]string{
+				label.ClusterNameLabelName: "es",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+	for _, claim := range claims {
+		s.Spec.VolumeClaimTemplates = append(s.Spec.VolumeClaimTemplates, corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: claim,
+			},
+		})
+	}
+	return s
+}
+
+func buildPVC(name string, ownerRefs ...string) corev1.PersistentVolumeClaim {
+	pvc := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      name,
+			Labels: map[string]string{
+				label.ClusterNameLabelName: "es",
+			},
+		},
+	}
+	for _, ref := range ownerRefs {
+		pvc.OwnerReferences = append(pvc.OwnerReferences, metav1.OwnerReference{Name: ref})
+	}
+	return pvc
+}
+
+func buildPVCPtr(name string, ownerRefs ...string) *corev1.PersistentVolumeClaim {
+	pvc := buildPVC(name, ownerRefs...)
+	return &pvc
+}
+
+func Test_pvcsToRemove(t *testing.T) {
+	type args struct {
+		pvcs                 []corev1.PersistentVolumeClaim
+		actualStatefulSets   sset.StatefulSetList
+		expectedStatefulSets sset.StatefulSetList
+	}
+	tests := []struct {
+		name string
+		args args
+		want []corev1.PersistentVolumeClaim
+	}{
+		{
+			name: "no pvc in the cache: nothing to remove",
+			args: args{
+				pvcs:                 nil,
+				actualStatefulSets:   sset.StatefulSetList{buildSsetWithClaims("sset1", 3, "claim1")},
+				expectedStatefulSets: sset.StatefulSetList{buildSsetWithClaims("sset1", 4, "claim1", "claim2")},
+			},
+			want: nil,
+		},
+		{
+			name: "expected pvcs are there: nothing to remove",
+			args: args{
+				pvcs:                 []corev1.PersistentVolumeClaim{buildPVC("claim1-sset1-0"), buildPVC("claim1-sset1-1")},
+				actualStatefulSets:   sset.StatefulSetList{buildSsetWithClaims("sset1", 2, "claim1")},
+				expectedStatefulSets: sset.StatefulSetList{buildSsetWithClaims("sset1", 2, "claim1")},
+			},
+			want: nil,
+		},
+		{
+			name: "don't remove PVCs of expected pods that may be created concurrently, or existing pods that are not deleted yet",
+			args: args{
+				pvcs:                 []corev1.PersistentVolumeClaim{buildPVC("claim1-sset1-0"), buildPVC("claim1-sset1-1"), buildPVC("claim1-sset2-0")},
+				actualStatefulSets:   sset.StatefulSetList{buildSsetWithClaims("sset1", 2, "claim1")},
+				expectedStatefulSets: sset.StatefulSetList{buildSsetWithClaims("sset2", 2, "claim1")},
+			},
+			want: nil,
+		},
+		{
+			name: "remove PVCs that don't match actual nor expected ssets",
+			args: args{
+				pvcs:                 []corev1.PersistentVolumeClaim{buildPVC("claim1-sset1-0"), buildPVC("claim1-sset3-0"), buildPVC("claim1-sset3-1")},
+				actualStatefulSets:   sset.StatefulSetList{buildSsetWithClaims("sset1", 2, "claim1")},
+				expectedStatefulSets: sset.StatefulSetList{buildSsetWithClaims("sset2", 2, "claim1")},
+			},
+			want: []corev1.PersistentVolumeClaim{buildPVC("claim1-sset3-0"), buildPVC("claim1-sset3-1")},
+		},
+		{
+			name: "remove PVCs corresponding to claims that don't exist anymore in sset specs",
+			args: args{
+				pvcs:                 []corev1.PersistentVolumeClaim{buildPVC("oldclaim-sset1-0"), buildPVC("newclaim-sset1-0")},
+				actualStatefulSets:   sset.StatefulSetList{buildSsetWithClaims("sset1", 1, "newclaim")},
+				expectedStatefulSets: sset.StatefulSetList{buildSsetWithClaims("sset2", 1, "newclaim")},
+			},
+			want: []corev1.PersistentVolumeClaim{buildPVC("oldclaim-sset1-0")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pvcsToRemove(tt.args.pvcs, tt.args.actualStatefulSets, tt.args.expectedStatefulSets); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("pvcsToRemove() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGarbageCollectPVCs(t *testing.T) {
+	require.NoError(t, v1alpha1.AddToScheme(scheme.Scheme))
+	es := v1alpha1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "es"}}
+	existingPVCS := []runtime.Object{
+		buildPVCPtr("claim1-sset1-0"),   // should have its ownerRef patched
+		buildPVCPtr("claim1-sset2-0"),   // should have its ownerRef patched
+		buildPVCPtr("claim1-oldsset-0"), // should be removed
+	}
+	actualSsets := sset.StatefulSetList{buildSsetWithClaims("sset1", 1, "claim1")}
+	expectedSsets := sset.StatefulSetList{buildSsetWithClaims("sset2", 1, "claim1")}
+	k8sClient := k8s.WrapClient(fake.NewFakeClient(existingPVCS...))
+	err := GarbageCollectPVCs(k8sClient, scheme.Scheme, es, actualSsets, expectedSsets)
+	require.NoError(t, err)
+
+	var retrievedPVCs corev1.PersistentVolumeClaimList
+	require.NoError(t, k8sClient.List(&client.ListOptions{}, &retrievedPVCs))
+	require.Equal(t, 2, len(retrievedPVCs.Items))
+	for _, pvc := range retrievedPVCs.Items {
+		require.Equal(t, es.Name, pvc.OwnerReferences[0].Name)
+	}
+}

--- a/pkg/controller/elasticsearch/sset/list.go
+++ b/pkg/controller/elasticsearch/sset/list.go
@@ -5,6 +5,8 @@
 package sset
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,6 +70,20 @@ func (l StatefulSetList) PodNames() []string {
 		names = append(names, PodNames(s)...)
 	}
 	return names
+}
+
+// PVCNames returns the names of PVCs for all pods of the StatefulSetList.
+func (l StatefulSetList) PVCNames() []string {
+	var pvcNames []string
+	for _, s := range l {
+		podNames := PodNames(s)
+		for _, claim := range s.Spec.VolumeClaimTemplates {
+			for _, podName := range podNames {
+				pvcNames = append(pvcNames, fmt.Sprintf("%s-%s", claim.Name, podName))
+			}
+		}
+	}
+	return pvcNames
 }
 
 // GetActualPods returns the list of pods currently existing in the StatefulSetList.

--- a/test/e2e/test/elasticsearch/steps_deletion.go
+++ b/test/e2e/test/elasticsearch/steps_deletion.go
@@ -5,6 +5,7 @@
 package elasticsearch
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -59,9 +60,8 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 			}),
 		},
 		{
-			Name: "Remove leftover PVCs",
-			// TODO: remove when https://github.com/elastic/cloud-on-k8s/issues/1288 is fixed.
-			Test: func(t *testing.T) {
+			Name: "PVCs should eventually be removed",
+			Test: test.Eventually(func() error {
 				var pvcs corev1.PersistentVolumeClaimList
 				err := k.Client.List(&client.ListOptions{
 					Namespace: b.Elasticsearch.Namespace,
@@ -69,12 +69,14 @@ func (b Builder) DeletionTestSteps(k *test.K8sClient) test.StepList {
 						label.ClusterNameLabelName: b.Elasticsearch.Name,
 					}),
 				}, &pvcs)
-				require.NoError(t, err)
-				for _, pvc := range pvcs.Items {
-					err := k.Client.Delete(&pvc)
-					require.NoError(t, err)
+				if err != nil {
+					return err
 				}
-			},
+				if len(pvcs.Items) != 0 {
+					return fmt.Errorf("%d pvcs still present", len(pvcs.Items))
+				}
+				return nil
+			}),
 		},
 	}
 }


### PR DESCRIPTION
Let's not keep PVCs around when Elasticsearch nodes are removed, since
it can be very confusing if there are reused in a different context (eg.
new cluster with the same old name, or upscale long after a downscale).

This is done in 2 ways:
- patch PVCs created by the StatefulSet controller with the ES resource
as owner reference, to delete PVCs on cluster deletion.
- delete unused PVCs, based on their naming conventions and what we
expect to exist from actual & expected StatefulSets.

Note we do not remove PVs, only PVCs. PVs deletion is left to the
storage class reclaim policy responsibility.

<!--
Thank you for your interest in contributing to Elastic Cloud on Kubernetes!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/cloud-on-k8s/tree/master/CONTRIBUTING.md)?
- If you submit code, is your pull request against master? We recommend pull requests against master. We will backport them as needed.
